### PR TITLE
Wrap input inside quotes

### DIFF
--- a/lib/wkhtmltopdf.js
+++ b/lib/wkhtmltopdf.js
@@ -28,9 +28,9 @@ function wkhtmltopdf(options, input, output) {
 
     // Execute
     if (process.platform === 'win32') {
-        child = spawn('wkhtmltopdf', options + ' ' + input + ' ' + output);
+        child = spawn('wkhtmltopdf', options + ' "' + input + '" ' + output);
     } else {
-        child = spawn('/bin/sh', ['-c', 'wkhtmltopdf ' + options + ' ' + input + ' ' + output + ' | cat']);
+        child = spawn('/bin/sh', ['-c', 'wkhtmltopdf ' + options + ' "' + input + '" ' + output + ' | cat']);
     }
 
     if (!isUrl) {


### PR DESCRIPTION
If the input URL contains a hashtag, without quoting it, when
wkhtmltopdf is called via child_process that part will be ignored.

Tested locally with stdin wrapped as well ( "-" ), however wasn't quite sure how to write a unit test for that.
